### PR TITLE
Automation API Python REST example

### DIFF
--- a/201-call-rest-api-using-python/README.md
+++ b/201-call-rest-api-using-python/README.md
@@ -1,0 +1,55 @@
+# How to make REST calls to Automation API in Python
+
+## Features:
+- login by proving username, password, and hostname by command line flags
+- The user will be prompted for any required inputs if they are not specified on the command line
+- disable SSL Certificate Signing (Useful when testing Automation API becuase it will deploy with a self signed cert by default)
+- Enable verbose mode to see more details about the calls being made
+- Gives a list of jobs in the AJF
+- lets the users choose one to view the output
+- After viewing output the user can enter 'q' to quit or chose another job
+
+## Usage: 
+    usage: getoutput.py [-u USERNAME] [-p PASSWORD] [-h HOST] [-i] [-v] [--help]
+    
+    Connect to Control-M/Enterprise Manager via Automation API REST calls and display job outputs
+    
+    optional arguments:
+      -u USERNAME, --username USERNAME
+                            Username to login to Control-M/Enterprise Manager
+      -p PASSWORD, --password PASSWORD
+                            Passowrd to login to Control-M/Enterprise Manager
+      -h HOST, --host HOST  Control-M/Enterprise Manager hostname
+      -i, --insecure        Disable SSL Certification Verification
+      -v, --verbose         Turn on verbose mode
+      --help                show this help message and exit
+
+- HOST is the hostname of the Control-M/Enterprise Manager where the Automation API Rest Server is running
+- USERNAME is the username you use to log into Control-M/Enterprise Manager
+- PASSWORD is the password for that user account
+- insecure will allow you to connect to an Automation API Rest Server that is using an untrusted certificate, this is useful because Automation API uses a self signed cert by default
+- verbose will output the url that is being used eachtime as well as JSON header information
+- help prints the above useage message
+
+## Rest in Python
+Making rest calls in python is actually fairly simple using the requests package: [http://docs.python-requests.org/en/master/](http://docs.python-requests.org/en/master/)
+### To do a get on a URL:
+```python
+r = requests.get(www.example.com/rest/end/point) # Makes r an object conaining information about the request and the response data
+print(r.text) # r.text is the raw response
+print(json.dumps(json.loads(r.text)['someObjects'][0])) # if the response if in JSON and you wish to output only certain feilds you can load it as a json object
+```
+### To do a post on a URL:
+```python
+body = json.loads('{ "foo": "bar", "iAm": "postData" }') # use json.loads to make a json object to use as the post body
+r = requests.post(www.example.com/rest/end/point/post, json=body) # json= automatically sets the content type for this request to json
+if r.status_code == 200: # r.status_code holds the HTTP status code and can be useful for error handling in addition too the exceptions in the requests using a try except block
+    exit(0)
+else:
+    exit(1)
+```
+### Headers in a request:
+```python
+head = json.loads('{ "foo": "bar", "iAm": "headerData" }') # just like body content for a post make a json object
+r = request.get(www.example.com/rest/end/point/requires-header-data, header=head)
+```

--- a/201-call-rest-api-using-python/getoutput.py
+++ b/201-call-rest-api-using-python/getoutput.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+
+import json
+import requests
+import argparse
+from getpass import getpass
+from requests.exceptions import *
+import urllib3
+from urllib3.exceptions import *
+urllib3.disable_warnings(InsecureRequestWarning)
+
+# import warnings
+# import requests
+# from requests.packages.urllib3 import exceptions
+
+# with warnings.catch_warnings():
+    # warnings.simplefilter("ignore", exceptions.InsecureRequestWarning)
+
+parser = argparse.ArgumentParser(description='Connect to Control-M/Enterprise Manager via Automation API REST calls and display job outputs',add_help=False)
+parser.add_argument('-u', '--username', dest='username', type=str, help='Username to login to Control-M/Enterprise Manager')
+parser.add_argument('-p', '--password', dest='password', type=str, help='Passowrd to login to Control-M/Enterprise Manager')
+parser.add_argument('-h', '--host', dest='host', type=str, help='Control-M/Enterprise Manager hostname')
+parser.add_argument('-i', '--insecure', dest='insecure', action='store_const', const=True, help='Disable SSL Certification Verification')
+parser.add_argument('-v', '--verbose', dest='verbose', action='store_const', const=True, help='Turn on verbose mode')
+parser.add_argument("--help", action="help", help="show this help message and exit")
+
+args = parser.parse_args()
+
+verbose = args.verbose
+
+if args.insecure:
+    urllib3.disable_warnings(InsecureRequestWarning)
+    verify_certs=False
+else:
+    verify_certs=True
+
+host = args.host
+if host == None:
+    host = raw_input("EM Hostname: ")
+username = args.username
+if username == None:
+    username = raw_input("EM username: ")
+password = args.password
+if password == None:
+    password = getpass("Passowrd: ")
+baseurl = 'https://'+host+':8443/automation-api/'
+
+if verbose:
+    print('base URL: '+baseurl)
+
+loginurl =baseurl+'session/login'
+body =json.loads('{ "password": "'+password+'", "username": "'+username+'"}')
+try:
+    r = requests.post(loginurl, json=body, verify=verify_certs)
+except:
+    print("Connecting to Automation API REST Server failed")
+    quit(1)
+
+if verbose:
+	print(r.text)
+	print(json.dumps(json.loads(r.text)['errors'][0]['message']))
+
+if json.dumps(json.loads(r.text)['errors'][0]['message'])=='"Failed to login: Incorrect username or password"':
+	print('Bad Username or Passowrd')
+	quit(1)
+
+token = json.loads(r.text)['token']
+
+if verbose:
+    print('Token: '+token)
+
+jobstatusurl =baseurl+'run/jobs/status?token='+token
+
+if verbose:
+    print('Job Status URL: '+jobstatusurl)
+
+r2 = requests.get(jobstatusurl, verify=verify_certs)
+statuses = json.loads(r2.text)['statuses']
+
+# if verbose:
+    # print('statuses:\n'+json.dumbs(statuses)
+
+length = len(json.loads(r2.text)['statuses'])
+
+if verbose:
+    print('length: '+length)
+
+x = 0
+while x < length:
+    if verbose:
+        print(str(x))
+    jsonobject = json.loads(r2.text)
+    if jsonobject['statuses'][x]['type'] == 'Command':
+        outputurl = jsonobject['statuses'][x]['outputURI']
+        print(outputurl)
+        r3 = requests.get(outputurl, verify=verify_certs)
+        print(r3.text)
+    x += 1

--- a/201-call-rest-api-using-python/getoutput.py
+++ b/201-call-rest-api-using-python/getoutput.py
@@ -50,13 +50,22 @@ except:
 
 if verbose:
     print(r.text)
-    print(json.dumps(json.loads(r.text)['errors'][0]['message']))
+    print(r.status_code)
 
-if json.dumps(json.loads(r.text)['errors'][0]['message'])=='"Failed to login: Incorrect username or password"':
-    print('Bad Username or Passowrd')
+loginresponce = json.loads(r.text)
+if 'errors' in loginresponce:
+    print(json.dumps(loginresponce['errors'][0]['message']))
     quit(1)
 
-token = json.loads(r.text)['token']
+#if r.status_code != 200:
+#    if json.dumps(json.loads(r.text)['errors'][0]['message'])=='"Failed to login: Incorrect username or password"':
+#        print('Bad Username or Password')
+#        quit(1)
+if 'token' in loginresponce:
+    token = json.loads(r.text)['token']
+else:
+    print("Failed to get token for unknown reason, exiting...")
+    quit(2)
 
 if verbose:
     print('Token: '+token)
@@ -79,12 +88,26 @@ if verbose:
 
 x = 0
 while x < length:
-    if verbose:
-        print(str(x))
-    jsonobject = json.loads(r2.text)
-    if jsonobject['statuses'][x]['type'] == 'Command':
-        outputurl = jsonobject['statuses'][x]['outputURI']
-        print(outputurl)
-        r3 = requests.get(outputurl, verify=verify_certs)
-        print(r3.text)
-    x += 1
+    print('1. '+statuses[x]['jobid']+', '+statuses[x]['name']+', '+statuses[x]['status']+', '+statuses[x]['type'])
+    x +=1
+
+selected = raw_input("Enter the it's output to view: ")
+
+outputurl = statuses[selected]['outputURI']
+
+if verbose:
+    print(outputurl)
+
+r3 = requests.get(outputurl, verify=verify_certs)
+print(r3.text)
+#x = 0
+#while x < length:
+#    if verbose:
+#        print('Job ' + str(x) +' of ' + length + ' in in responce: ')
+#    jsonobject = json.loads(r2.text)
+#    if jsonobject['statuses'][x]['type'] == 'Command':
+#        outputurl = jsonobject['statuses'][x]['outputURI']
+#        print(outputurl)
+#        r3 = requests.get(outputurl, verify=verify_certs)
+#        print(r3.text)
+#    x += 1

--- a/201-call-rest-api-using-python/getoutput.py
+++ b/201-call-rest-api-using-python/getoutput.py
@@ -4,17 +4,9 @@ import json
 import requests
 import argparse
 from getpass import getpass
-from requests.exceptions import *
 import urllib3
 from urllib3.exceptions import *
 urllib3.disable_warnings(InsecureRequestWarning)
-
-# import warnings
-# import requests
-# from requests.packages.urllib3 import exceptions
-
-# with warnings.catch_warnings():
-    # warnings.simplefilter("ignore", exceptions.InsecureRequestWarning)
 
 parser = argparse.ArgumentParser(description='Connect to Control-M/Enterprise Manager via Automation API REST calls and display job outputs',add_help=False)
 parser.add_argument('-u', '--username', dest='username', type=str, help='Username to login to Control-M/Enterprise Manager')
@@ -57,12 +49,12 @@ except:
     quit(1)
 
 if verbose:
-	print(r.text)
-	print(json.dumps(json.loads(r.text)['errors'][0]['message']))
+    print(r.text)
+    print(json.dumps(json.loads(r.text)['errors'][0]['message']))
 
 if json.dumps(json.loads(r.text)['errors'][0]['message'])=='"Failed to login: Incorrect username or password"':
-	print('Bad Username or Passowrd')
-	quit(1)
+    print('Bad Username or Passowrd')
+    quit(1)
 
 token = json.loads(r.text)['token']
 
@@ -77,8 +69,8 @@ if verbose:
 r2 = requests.get(jobstatusurl, verify=verify_certs)
 statuses = json.loads(r2.text)['statuses']
 
-# if verbose:
-    # print('statuses:\n'+json.dumbs(statuses)
+if verbose:
+    print('statuses:\n'+json.dumps(statuses))
 
 length = len(json.loads(r2.text)['statuses'])
 

--- a/201-call-rest-api-using-python/getoutput.py
+++ b/201-call-rest-api-using-python/getoutput.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import collections
 import json
 import requests
 import argparse
@@ -10,129 +11,158 @@ except:
     from urllib3.exceptions import InsecureRequestWarning
     import urllib3
 
-parser = argparse.ArgumentParser(description='Connect to Control-M/Enterprise Manager via Automation API REST calls and display job outputs',add_help=False)
-parser.add_argument('-u', '--username', dest='username', type=str, help='Username to login to Control-M/Enterprise Manager')
-parser.add_argument('-p', '--password', dest='password', type=str, help='Passowrd to login to Control-M/Enterprise Manager')
-parser.add_argument('-h', '--host', dest='host', type=str, help='Control-M/Enterprise Manager hostname')
-parser.add_argument('-i', '--insecure', dest='insecure', action='store_const', const=True, help='Disable SSL Certification Verification')
-parser.add_argument('-v', '--verbose', dest='verbose', action='store_const', const=True, help='Turn on verbose mode')
-parser.add_argument("--help", action="help", help="show this help message and exit")
+verbose = False
+verify_certs = True
 
-args = parser.parse_args()
+def parse_inputs():
+    parser = argparse.ArgumentParser(description='Connect to Control-M/Enterprise Manager via Automation API REST calls and display job outputs',add_help=False)
+    parser.add_argument('-u', '--username', dest='username', type=str, help='Username to login to Control-M/Enterprise Manager')
+    parser.add_argument('-p', '--password', dest='password', type=str, help='Passowrd to login to Control-M/Enterprise Manager')
+    parser.add_argument('-h', '--host', dest='host', type=str, help='Control-M/Enterprise Manager hostname')
+    parser.add_argument('-i', '--insecure', dest='insecure', action='store_const', const=True, help='Disable SSL Certification Verification')
+    parser.add_argument('-v', '--verbose', dest='verbose', action='store_const', const=True, help='Turn on verbose mode')
+    parser.add_argument("--help", action="help", help="show this help message and exit")
 
-verbose = args.verbose
-insecure = args.insecure
+    args = parser.parse_args()
 
-if insecure:
+    global verbose
+    global verify_certs
+
+    verbose = args.verbose
+    insecure = args.insecure
+
+    if insecure:
+        if verbose:
+            print('Disabling SSL Cert verification')
+        try:
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        except:
+            urllib3.disable_warnings(InsecureRequestWarning)
+        verify_certs=False
+    else:
+        verify_certs=True
+
+    host = args.host
+    if host == None:
+        host = raw_input("EM Hostname: ")
+    username = args.username
+    if username == None:
+        username = raw_input("EM username: ")
+    password = args.password
+    if password == None:
+        password = getpass("Passowrd: ")
+
+    baseurl = 'https://'+host+':8443/automation-api/'
+    login_args = collections.namedtuple('Login_Args', ['baseurl', 'username', 'password'])
+    auth = login_args(baseurl, username, password)
+    return auth
+
+
+def login(auth):
+    global verbose
+    baseurl = auth.baseurl
+    username = auth.username
+    password = auth.password
+
     if verbose:
-        print('Disabling SSL Cert verification')
+        print('base URL: '+baseurl)
+
+    loginurl =baseurl+'session/login'
+    body =json.loads('{ "password": "'+password+'", "username": "'+username+'"}')
     try:
-        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        r = requests.post(loginurl, json=body, verify=verify_certs)
+    except requests.exceptions.ConnectTimeout as err:
+        print("Connecting to Automation API REST Server failed with error: " + str(err))
+        quit(1)
+    except requests.exceptions.ConnectionError as err:
+        print("Connecting to Automation API REST Server failed with error: "+str(err))
+        if 'CERTIFICATE_VERIFY_FAILED' in str(err.message):
+            print('INFO: If using a Self Signed Certificate use the -i flag to disable cert verification or add the certificate to this systems trusted CA store')
+        quit(1)
+    except requests.exceptions.HTTPError as err:
+        print("Connecting to Automation API REST Server failed with error: "+str(err))
+        quit(1)
     except:
-        urllib3.disable_warnings(InsecureRequestWarning)
-    verify_certs=False
-else:
-    verify_certs=True
+        print("Connecting to Automation API REST Server failed with error unknown error")
+        quit(1)
 
-host = args.host
-if host == None:
-    host = raw_input("EM Hostname: ")
-username = args.username
-if username == None:
-    username = raw_input("EM username: ")
-password = args.password
-if password == None:
-    password = getpass("Passowrd: ")
-baseurl = 'https://'+host+':8443/automation-api/'
+    if verbose:
+        print(r.text)
+        print(r.status_code)
 
-if verbose:
-    print('base URL: '+baseurl)
+    loginresponce = json.loads(r.text)
+    if 'errors' in loginresponce:
+        print(json.dumps(loginresponce['errors'][0]['message']))
+        quit(1)
 
-loginurl =baseurl+'session/login'
-body =json.loads('{ "password": "'+password+'", "username": "'+username+'"}')
-try:
-    r = requests.post(loginurl, json=body, verify=verify_certs)
-except requests.exceptions.ConnectTimeout as err:
-    print("Connecting to Automation API REST Server failed with error: " + str(err))
-    quit(1)
-except requests.exceptions.ConnectionError as err:
-    print("Connecting to Automation API REST Server failed with error: "+str(err))
-    if 'CERTIFICATE_VERIFY_FAILED' in str(err.message):
-        print('INFO: If using a Self Signed Certificate use the -i flag to disable cert verification or add the certificate to this systems trusted CA store')
-    quit(1)
-except requests.exceptions.HTTPError as err:
-    print("Connecting to Automation API REST Server failed with error: "+str(err))
-    quit(1)
-except:
-    print("Connecting to Automation API REST Server failed with error unknown error")
-    quit(1)
+    if 'token' in loginresponce:
+        token = json.loads(r.text)['token']
+    else:
+        print("Failed to get token for unknown reason, exiting...")
+        quit(2)
 
-if verbose:
-    print(r.text)
-    print(r.status_code)
+    if verbose:
+        print('Token: '+token)
 
-loginresponce = json.loads(r.text)
-if 'errors' in loginresponce:
-    print(json.dumps(loginresponce['errors'][0]['message']))
-    quit(1)
-
-if 'token' in loginresponce:
-    token = json.loads(r.text)['token']
-else:
-    print("Failed to get token for unknown reason, exiting...")
-    quit(2)
-
-if verbose:
-    print('Token: '+token)
-
-jobstatusurl =baseurl+'run/jobs/status?token='+token
-
-if verbose:
-    print('Job Status URL: '+jobstatusurl)
-
-r2 = requests.get(jobstatusurl, verify=verify_certs)
-
-if 'statuses' in json.loads(r2.text):
-    statuses = json.loads(r2.text)['statuses']
-else:
-    print('No job statuses were loaded.')
-    quit(0)
-
-if verbose:
-    print('statuses:\n'+json.dumps(statuses))
-
-length = len(json.loads(r2.text)['statuses'])
-
-if verbose:
-    print('length: '+str(length))
-
-x = 0
-while x < length:
-    print(str(x)+'. '+statuses[x]['jobId']+', '+statuses[x]['name']+', '+statuses[x]['status']+', '+statuses[x]['type'])
-    x +=1
+    return token
 
 
-selected = int(input("Enter the it's output to view: "))
+def list_jobs(token, baseurl):
+    global verbose
+    jobstatusurl =baseurl+'run/jobs/status?token='+token
 
-if selected > length:
-    print('That does not exist')
-    quit(1)
+    if verbose:
+        print('Job Status URL: '+jobstatusurl)
 
-outputurl = statuses[selected]['outputURI']
+    r2 = requests.get(jobstatusurl, verify=verify_certs)
 
-if verbose:
-    print(outputurl)
+    if 'statuses' in json.loads(r2.text):
+        statuses = json.loads(r2.text)['statuses']
+    else:
+        print('No job statuses were loaded.')
+        quit(0)
 
-r3 = requests.get(outputurl, verify=verify_certs)
-print(r3.text)
-#x = 0
-#while x < length:
-#    if verbose:
-#        print('Job ' + str(x) +' of ' + length + ' in in responce: ')
-#    jsonobject = json.loads(r2.text)
-#    if jsonobject['statuses'][x]['type'] == 'Command':
-#        outputurl = jsonobject['statuses'][x]['outputURI']
-#        print(outputurl)
-#        r3 = requests.get(outputurl, verify=verify_certs)
-#        print(r3.text)
-#    x += 1
+    if verbose:
+        print('statuses:\n'+json.dumps(statuses))
+
+    length = len(json.loads(r2.text)['statuses'])
+
+    if verbose:
+        print('length: '+str(length))
+    while True:
+        x = 0
+        while x < length:
+            print(str(x)+'. '+statuses[x]['jobId']+', '+statuses[x]['name']+', '+statuses[x]['status']+', '+statuses[x]['type'])
+            x +=1
+
+
+        selected = raw_input("Enter a number to see it's output: ")
+
+        if selected == 'q':
+            quit(0)
+        try:
+            selected = int(selected)
+        except:
+            print("Please enter either a number or q to quit")
+            quit(1)
+
+        if selected > length:
+            print('That does not exist')
+            quit(1)
+
+        outputurl = statuses[selected]['outputURI']
+
+        print_output(outputurl)
+
+
+def print_output(outputurl):
+    global verbose
+    if verbose:
+        print(outputurl)
+
+    r3 = requests.get(outputurl, verify=verify_certs)
+    print(r3.text)
+
+args = parse_inputs()
+tok = login(args)
+list_jobs(tok, args.baseurl)

--- a/201-call-rest-api-using-python/getoutput.py
+++ b/201-call-rest-api-using-python/getoutput.py
@@ -104,7 +104,7 @@ if verbose:
 length = len(json.loads(r2.text)['statuses'])
 
 if verbose:
-    print('length: '+length)
+    print('length: '+str(length))
 
 x = 0
 while x < length:

--- a/201-call-rest-api-using-python/getoutput.py
+++ b/201-call-rest-api-using-python/getoutput.py
@@ -4,7 +4,9 @@ import collections
 import json
 import requests
 import argparse
+import sys
 from getpass import getpass
+
 try:
     from requests.packages.urllib3.exceptions import InsecureRequestWarning
 except:
@@ -14,13 +16,20 @@ except:
 verbose = False
 verify_certs = True
 
+
 def parse_inputs():
-    parser = argparse.ArgumentParser(description='Connect to Control-M/Enterprise Manager via Automation API REST calls and display job outputs',add_help=False)
-    parser.add_argument('-u', '--username', dest='username', type=str, help='Username to login to Control-M/Enterprise Manager')
-    parser.add_argument('-p', '--password', dest='password', type=str, help='Passowrd to login to Control-M/Enterprise Manager')
+    parser = argparse.ArgumentParser(
+        description='Connect to Control-M/Enterprise Manager via Automation API REST calls and display job outputs',
+        add_help=False)
+    parser.add_argument('-u', '--username', dest='username', type=str,
+                        help='Username to login to Control-M/Enterprise Manager')
+    parser.add_argument('-p', '--password', dest='password', type=str,
+                        help='Passowrd to login to Control-M/Enterprise Manager')
     parser.add_argument('-h', '--host', dest='host', type=str, help='Control-M/Enterprise Manager hostname')
-    parser.add_argument('-i', '--insecure', dest='insecure', action='store_const', const=True, help='Disable SSL Certification Verification')
-    parser.add_argument('-v', '--verbose', dest='verbose', action='store_const', const=True, help='Turn on verbose mode')
+    parser.add_argument('-i', '--insecure', dest='insecure', action='store_const', const=True,
+                        help='Disable SSL Certification Verification')
+    parser.add_argument('-v', '--verbose', dest='verbose', action='store_const', const=True,
+                        help='Turn on verbose mode')
     parser.add_argument("--help", action="help", help="show this help message and exit")
 
     args = parser.parse_args()
@@ -31,16 +40,16 @@ def parse_inputs():
     verbose = args.verbose
     insecure = args.insecure
 
-    if insecure: # Use insecure to disable verifing SSL Cert on server useful becuase Automation API will use a selfsigned cert by default
+    if insecure:  # Use insecure to disable verifing SSL Cert on server useful becuase Automation API will use a selfsigned cert by default
         if verbose:
             print('Disabling SSL Cert verification')
         try:
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
         except:
             urllib3.disable_warnings(InsecureRequestWarning)
-        verify_certs=False
+        verify_certs = False
     else:
-        verify_certs=True
+        verify_certs = True
 
     host = args.host
     if host == None:
@@ -50,12 +59,16 @@ def parse_inputs():
         username = raw_input("EM username: ")
     password = args.password
     if password == None:
-        password = getpass("Passowrd: ")
+        try:
+            password = getpass("Passowrd: ",
+                           sys.stderr)  # getpass has an issue using /dev/tty as the stream (second argument) using sys.stderr is the alternative, this argument is ignored on windows
+        except:
+            password = raw_input("Password: ") # adding try & execpt block to fail back to raw_input encase getpass encounters an error
 
-    baseurl = 'https://'+host+':8443/automation-api/' # Control-M Automation API v2 (EM 9 FP3) base url
+    baseurl = 'https://' + host + ':8443/automation-api/'  # Control-M Automation API v2 (EM 9 FP3) base url
     login_args = collections.namedtuple('Login_Args', ['baseurl', 'username', 'password'])
     auth = login_args(baseurl, username, password)
-    return auth #return auth info as named tuple
+    return auth  # return auth info as named tuple
 
 
 def login(auth):
@@ -65,22 +78,24 @@ def login(auth):
     password = auth.password
 
     if verbose:
-        print('base URL: '+baseurl)
+        print('base URL: ' + baseurl)
 
-    loginurl =baseurl+'session/login' # The login url
-    body =json.loads('{ "password": "'+password+'", "username": "'+username+'"}') # create a json object to use as the body of the post to the login url
+    loginurl = baseurl + 'session/login'  # The login url
+    body = json.loads(
+        '{ "password": "' + password + '", "username": "' + username + '"}')  # create a json object to use as the body of the post to the login url
     try:
         r = requests.post(loginurl, json=body, verify=verify_certs)
     except requests.exceptions.ConnectTimeout as err:
         print("Connecting to Automation API REST Server failed with error: " + str(err))
         quit(1)
     except requests.exceptions.ConnectionError as err:
-        print("Connecting to Automation API REST Server failed with error: "+str(err))
+        print("Connecting to Automation API REST Server failed with error: " + str(err))
         if 'CERTIFICATE_VERIFY_FAILED' in str(err.message):
-            print('INFO: If using a Self Signed Certificate use the -i flag to disable cert verification or add the certificate to this systems trusted CA store')
+            print(
+            'INFO: If using a Self Signed Certificate use the -i flag to disable cert verification or add the certificate to this systems trusted CA store')
         quit(1)
     except requests.exceptions.HTTPError as err:
-        print("Connecting to Automation API REST Server failed with error: "+str(err))
+        print("Connecting to Automation API REST Server failed with error: " + str(err))
         quit(1)
     except:
         print("Connecting to Automation API REST Server failed with error unknown error")
@@ -95,48 +110,55 @@ def login(auth):
         print(json.dumps(loginresponce['errors'][0]['message']))
         quit(1)
 
-    if 'token' in loginresponce: # If token exists in the json response set the value to the variable token
+    if 'token' in loginresponce:  # If token exists in the json response set the value to the variable token
         token = json.loads(r.text)['token']
     else:
         print("Failed to get token for unknown reason, exiting...")
         quit(2)
 
     if verbose:
-        print('Token: '+token)
+        print('Token: ' + token)
 
-    return token # return the token
+    return token  # return the token
 
 
 def list_jobs(token, baseurl):
     global verbose
-    jobstatusurl =baseurl+'run/jobs/status?token='+token # url to list statuses of all the jobs in the AJF using the token from login() for auth
+    jobstatusurl = baseurl + 'run/jobs/status'  # url to list statuses of all the jobs in the AJF
+
+    data = json.loads(
+        '{"Authorization": "Bearer ' + token + '"}')  # the jobs statues call should have the token in the header as JSON
 
     if verbose:
-        print('Job Status URL: '+jobstatusurl)
+        print('Job Status URL: ' + jobstatusurl)
+        print('Job Status Header: ' + json.dumps(data))
 
-    r2 = requests.get(jobstatusurl, verify=verify_certs) # do a get on the job status url returns json with all of the job status
+    r2 = requests.get(jobstatusurl, headers=data,
+                      verify=verify_certs)  # do a get on the job status url returns json with all of the job status
 
-    if 'statuses' in json.loads(r2.text): # if statuses exsits in json response store the statuses to variable statuses
+    if 'statuses' in json.loads(r2.text):  # if statuses exsits in json response store the statuses to variable statuses
         statuses = json.loads(r2.text)['statuses']
     else:
-        print('No job statuses were loaded.') # if statuses does not exist, report it. this can happen if no jobs are in the AJF
-        logout(token, baseurl, 0) # or if you've added a filter to the job statues url that has no results
+        print(
+        'No job statuses were loaded.')  # if statuses does not exist, report it. this can happen if no jobs are in the AJF
+        logout(token, baseurl, 0)  # or if you've added a filter to the job statues url that has no results
 
     if verbose:
-        print('statuses:\n'+json.dumps(statuses))
+        print('statuses:\n' + json.dumps(statuses))
 
-    length = len(json.loads(r2.text)['statuses']) # check how many jobs are in statuses
+    length = len(json.loads(r2.text)['statuses'])  # check how many jobs are in statuses
 
     if verbose:
-        print('length: '+str(length))
+        print('length: ' + str(length))
     while True:
         x = 0
-        while x < length: # iterate though statuses
+        while x < length:  # iterate though statuses
             # contents of python json objects can be accessed like named tupel for key value pairs and arrays for repeated objects
             # the end result is similar to jsonpath expressions statuses[3]['jobId'] is equivalent to 3.jobId, you can test and learn about jsonpath expressions here: https://jsonpath.curiousconcept.com/
-            print(str(x)+'. '+statuses[x]['jobId']+', '+statuses[x]['name']+', '+statuses[x]['status']+', '+statuses[x]['type'])
-            x +=1
-
+            print(
+            str(x) + '. ' + statuses[x]['jobId'] + ', ' + statuses[x]['name'] + ', ' + statuses[x]['status'] + ', ' +
+            statuses[x]['type'])
+            x += 1
 
         selected = raw_input("Enter a number to see it's output: ")
 
@@ -152,7 +174,7 @@ def list_jobs(token, baseurl):
             print('That does not exist')
             logout(token, baseurl, 1)
 
-        outputurl = statuses[selected]['outputURI'] # get the outputURI from the select job in statuses
+        outputurl = statuses[selected]['outputURI']  # get the outputURI from the select job in statuses
 
         print_output(outputurl)
 
@@ -162,22 +184,27 @@ def print_output(outputurl):
     if verbose:
         print(outputurl)
 
-    r3 = requests.get(outputurl, verify=verify_certs) # go a get on the outputURI, outputURI already includes the current token
-    print(r3.text) # this request returns the raw text output of the job and not json
+    r3 = requests.get(outputurl,
+                      verify=verify_certs)  # go a get on the outputURI, outputURI already includes the current token
+    print(r3.text)  # this request returns the raw text output of the job and not json
 
-def logout(token, baseurl, exit=0): # if logged in, need to call logout before quiting to invalidate the token for security
+
+def logout(token, baseurl,
+           exit=0):  # if logged in, need to call logout before quiting to invalidate the token for security
     # this prevents the chance of intercepting a token and being reused later
     global verbose
     global username
-    logouturl = baseurl + 'session/logout' # Automation API logout url
-    #logouturl = baseurl + 'session/logout?token=' + token # Automation API logout url
+    logouturl = baseurl + 'session/logout'  # Automation API logout url
+    # logouturl = baseurl + 'session/logout?token=' + token # Automation API logout url
 
     if verbose:
-        print('Logout URL: '+logouturl)
+        print('Logout URL: ' + logouturl)
 
-    body = json.loads('{ "token": "' + token + '", "username": "' + username + '"}') #logout url needs json with the token and username
+    body = json.loads(
+        '{ "token": "' + token + '", "username": "' + username + '"}')  # logout url needs json with the token and username
 
-    r4 = requests.post(logouturl, data=body, verify=verify_certs) #a post on this url invalidates the token with the above json as the post data
+    r4 = requests.post(logouturl, data=body,
+                       verify=verify_certs)  # a post on this url invalidates the token with the above json as the post data
     if verbose:
         print(r4.headers)
 
@@ -185,6 +212,7 @@ def logout(token, baseurl, exit=0): # if logged in, need to call logout before q
         print(r4.text)
 
     quit(exit)
+
 
 args = parse_inputs()
 username = args.username

--- a/201-call-rest-api-using-python/requirements.txt
+++ b/201-call-rest-api-using-python/requirements.txt
@@ -1,0 +1,2 @@
+requests
+urllib3

--- a/201-call-rest-api-using-python/requirements.txt
+++ b/201-call-rest-api-using-python/requirements.txt
@@ -1,2 +1,2 @@
-requests
 urllib3
+requests


### PR DESCRIPTION
This python example does the following:

- takes command line arguments or prompts user for username, password, and hostname

- give optional command line arguments for disabling SSL Cert verification and enable verbose mode

- uses built python json for parsing json objects

- Requires requests and urllib3 to make REST calls over https (requirements.txt included for easy depenancing installation with pip)

- provides some error checking for initial connection attempt to login and when accessing data inside json objects

- lists the JobId, name, status, and type of all jobs and allows the user to choose a job to view the output of (repeats until q is entered to quit)

- When ever exit happens and the user is already logged in, does logout to invalidate token

- Is heavily commented to provide easy use as an example
