### PR TITLE
Update Dockerfile

### DIFF
--- a/102-build-docker-containers-for-batch-application/centos7-agent/Dockerfile
+++ b/102-build-docker-containers-for-batch-application/centos7-agent/Dockerfile
@@ -14,7 +14,8 @@ RUN yum -y update \
 	&& yum -y install wget \
 	&& yum -y install unzip \
 	&& yum -y install sudo \
-	&& yum -y install net-tools
+	&& yum -y install net-tools \ 
+	&& yum -y install which
 
 # install nodejs
 RUN curl --silent --location https://rpm.nodesource.com/setup_6.x | bash - \


### PR DESCRIPTION
Missing which command generates errors during installation process from trace.log

2018-03-08 15:15:00 (InstallEnv_ExecuteSyncCommand) Command output: /home/controlm/ctm/cm/AFT/exe/keystoreutil_ga: line 5: which: command not found
2018-03-08 15:15:00 (InstallEnv_SetProperty) Setting property convert_aft_ssl_keystore_OUTPUT to '/home/controlm/ctm/cm/AFT/exe/keystoreutil_ga: line 5: which: command not found
2018-03-08 15:15:00 (InstallEnv_SetProperty) Setting property LAST_EXIT_OUTPUT to '/home/controlm/ctm/cm/AFT/exe/keystoreutil_ga: line 5: which: command not found