### PR TITLE
fix compilation error due to errors in merge (method appear twice)

### DIFF
--- a/103-test-automation-JUnit-workflow-examples/src/main/java/com/bmc/services/run/RunService.java
+++ b/103-test-automation-JUnit-workflow-examples/src/main/java/com/bmc/services/run/RunService.java
@@ -97,10 +97,6 @@ public class RunService {
 		sleep(5);
 		return this;
 	}
-	public RunService runJobs (File definitionsFile) throws ApiException{
-		return runJobs(definitionsFile, null);
-	}
-	
 	
 	/**
 	 * overloading runJobs without deploy descriptor file


### PR DESCRIPTION
error in code - method appear twice, probably a merge error.
FIX: delete the extra empty method