### PR TITLE
npm 6.x is unsupported. Please use 12.x

### DIFF
--- a/102-build-docker-containers-for-batch-application/centos7-agent/Dockerfile
+++ b/102-build-docker-containers-for-batch-application/centos7-agent/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y update \
 	&& yum -y install which
 
 # install nodejs
-RUN curl --silent --location https://rpm.nodesource.com/setup_6.x | bash - \
+RUN curl --silent --location https://rpm.nodesource.com/setup_12.x | bash - \
 	&& yum -y install nodejs \
 	&& node -v \
 	&& npm -v


### PR DESCRIPTION
The use of 6.x is no longer supported and results in a warning during installation.