### PR TITLE
Update decommission_controlm.sh

### DIFF
--- a/control-m/102-build-docker-containers-for-batch-application/centos7-agent/decommission_controlm.sh
+++ b/control-m/102-build-docker-containers-for-batch-application/centos7-agent/decommission_controlm.sh
@@ -4,7 +4,7 @@ CTM_ENV=endpoint
 #CTM_SERVER=[CTM_HOST]
 #CTM_HOSTGROUP=app1 
 #CTM_AGENT_PORT=7020
-ALIAS=$(hostname):$CTM_AGENT_PORT/
+ALIAS=$(hostname):$CTM_AGENT_PORT
 
 #cd
 #source .bash_profile


### PR DESCRIPTION
the slash is invalid in the Control-M/Agent name, unable to run ctm commands with slash present